### PR TITLE
Don't add null to the get list

### DIFF
--- a/src/PleskX/Api/Operator/Mail.php
+++ b/src/PleskX/Api/Operator/Mail.php
@@ -48,7 +48,9 @@ class Mail extends \PleskX\Api\Operator
 
         $forwards = [];
         foreach ($response->mail->get_info->result as $forwardInfo) {
-            $forwards[] = new Struct\Forwards($forwardInfo->mailname);
+            if (isset($forwardInfo->mailname)) {
+                $forwards[] = new Struct\Forwards($forwardInfo->mailname);
+            }
         }
 
         return $forwards;


### PR DESCRIPTION
If there are no forwards, plesk still returns a single array with an element called "status" and that's it. We don't really want that, it behaves oddly